### PR TITLE
Refactor for AHK v2, remove PS dependency

### DIFF
--- a/blink1-busy-light/Blink1-Busy-Light.ahk
+++ b/blink1-busy-light/Blink1-Busy-Light.ahk
@@ -1,15 +1,19 @@
-﻿; version 1.0, released 8/26/2024
+﻿; version 2.0, released 9/18/2024
+; Updates syntax for AHK 2.0
+; Eliminates powershell dependency
 
-; AutoHotkey Script to toggle between two PowerShell commands
-; Press Ctrl+Shift+1 to toggle between executing two PowerShell commands
+; Press Ctrl+Shift+1 to toggle state of Blink(1) device
+; Update 'exepath' with location of your blink1-tool.exe binary
 
-; Initialize a toggle variable
-toggle := 0
+ExePath := "Z:\\mthorn\\blink1-tool.exe"
+toggle := 0  ; Initialize the toggle variable
 
-^+1:: ; Ctrl+Shift+1
-    if (toggle := !toggle) {
-        Run, powershell.exe -Command "Start-Process -NoNewWindow -FilePath 'Z:\mthorn\blink1-tool.exe' -ArgumentList '-m 2000 --red -q'"
-    } else {
-        Run, powershell.exe -Command "Start-Process -NoNewWindow -FilePath 'Z:\mthorn\blink1-tool.exe' -ArgumentList '-m 2000 --off -q'"
-    }
-return
+^+1:: {
+	global toggle
+	global ExePath
+    toggle := !toggle  ; Toggle the state
+    color := toggle ? "red" : "off"  ; Determine the color based on the toggle
+    args := "-m 2000 --" color " -q"
+    ; Run the executable directly, hiding any window
+    Run('"' exePath '" ' args, "", "Hide")
+}


### PR DESCRIPTION
Updated escape syntax to be v2 compatible, eliminating the need for AHK 1.3 to be installed.

Removed powershell calls in favor of executing `blink1-tool.exe` directly. This eliminates a distracting PS shell popup, and executes faster.